### PR TITLE
refactor: create less buckets for request & response size histogram

### DIFF
--- a/src/Library/Handlers/CommandRequestSizeMetricProvider.cs
+++ b/src/Library/Handlers/CommandRequestSizeMetricProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Prometheus;
 using PrometheusNet.MongoDb.Events;
 using PrometheusNet.MongoDb.Handlers;
+// ReSharper disable ComplexConditionExpression
 
 namespace PrometheusNet.Contrib.MongoDb.Handlers
 {
@@ -23,7 +24,7 @@ namespace PrometheusNet.Contrib.MongoDb.Handlers
             new HistogramConfiguration
             {
                 LabelNames = new[] { "command_type", "target_collection", "target_db" },
-                Buckets = new[] { 50.0, 5000.0, 25000.0, 102400.0, 1024.0 * 1024.0 }
+                Buckets = new[] { 512.0, 1024.0, 100.0 * 1024, 1024.0 * 1024.0 },
             });
 
         /// <summary>

--- a/src/Library/Handlers/CommandResponseSizeProvider.cs
+++ b/src/Library/Handlers/CommandResponseSizeProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Prometheus;
 using PrometheusNet.MongoDb.Events;
 using PrometheusNet.MongoDb.Handlers;
+// ReSharper disable ComplexConditionExpression
 
 /// <summary>
 /// Provides metrics related to the size of MongoDB command responses.
@@ -17,7 +18,7 @@ internal class CommandResponseSizeProvider : IMetricProvider
         new HistogramConfiguration
         {
             LabelNames = new[] { "command_type", "target_collection", "target_db" },
-            Buckets = new[] { 50.0, 5000.0, 25000.0, 102400.0, 1024.0 * 1024.0 }
+            Buckets = new[] { 512.0, 1024.0, 100.0 * 1024, 1024.0 * 1024.0 },
         });
 
     /// <summary>


### PR DESCRIPTION
no need for better granularity to understand what's going on there - the new buckets of 512 bytes, 1kbyte, 100kbyte, 1mbyte should be enough to identify bottlenecks)