### PR TITLE
refactor: remove redundant metric, better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ Histogram metric that measures the duration of MongoDB commands in seconds.
 
 - Labels: `command_type`, `status`, `target_collection`, `target_db`
 
-### Command Duration (Summary) (`mongodb_client_command_duration_summary`)
-
-Summary metric that measures the duration of MongoDB commands in seconds.
-
-- Labels: `command_type`, `status`, `target_collection`, `target_db`
-
 ### Open Cursors Count (`mongodb_client_open_cursors_count`)
 
 Gauge metric that tracks the number of open cursors.

--- a/src/Library/Handlers/CommandDurationMetricProvider.cs
+++ b/src/Library/Handlers/CommandDurationMetricProvider.cs
@@ -28,42 +28,16 @@ internal class CommandDurationMetricProvider : IMetricProvider
         });
 
     /// <summary>
-    /// A Summary metric that captures the duration of MongoDB commands.
-    /// </summary>
-    /// <remarks>
-    /// The metric includes labels for the type of command, the status (success or failure), target collection, and target database.
-    /// Durations are measured in seconds.
-    /// </remarks>
-    public readonly Summary CommandDurationSummary = Metrics.CreateSummary(
-        "mongodb_client_command_duration_summary",
-        "Duration of MongoDB commands (seconds)",
-        new SummaryConfiguration
-        {
-            LabelNames = new[] { "command_type", "status", "target_collection", "target_db" },
-        });
-
-    public void Handle(MongoCommandEventStart e)
-    {
-        
-    }
-
-    /// <summary>
     /// Handles the event triggered when a MongoDB command successfully completes.
     /// </summary>
     /// <param name="e">Event information for the successfully completed MongoDB command.</param>
     /// <remarks>
     /// This will record the duration of successful MongoDB commands in the histogram with appropriate labels.
     /// </remarks>
-    public void Handle(MongoCommandEventSuccess e)
-    {
+    public void Handle(MongoCommandEventSuccess e) =>
         CommandDurationHistogram
             .WithLabels(e.OperationRawType, SuccessStatus, e.TargetCollection, e.TargetDatabase)
             .Observe(e.Duration.GetValueOrDefault().TotalSeconds);
-
-        CommandDurationSummary
-            .WithLabels(e.OperationRawType, SuccessStatus, e.TargetCollection, e.TargetDatabase)
-            .Observe(e.Duration.GetValueOrDefault().TotalSeconds);
-    }
 
     /// <summary>
     /// Handles the event triggered when a MongoDB command fails.


### PR DESCRIPTION
 "mongodb_client_command_duration_summary" - it provides roughly the same metrics as "mongodb_client_command_duration"