### PR TITLE
Fix/exclude dynamic assemblies from metric provider scan

### DIFF
--- a/src/Library/MetricProviderRegistrar.cs
+++ b/src/Library/MetricProviderRegistrar.cs
@@ -83,13 +83,8 @@ internal static class MetricProviderRegistrar
     private static IEnumerable<Type> EnumerateIMetricsHandlers()
     {
         var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-        foreach (var assembly in assemblies.Where(x => File.Exists(x.Location)))
+        foreach (var assembly in assemblies.Where(x => !x.IsDynamic && File.Exists(x.Location)))
         {
-            if (assembly.IsDynamic)
-            {
-                continue;
-            }
-
             if (ExcludedAssemblyPrefixes.Any(prefix => 
                     assembly.FullName.StartsWith(
                         prefix, StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
Closes #42 