### PR TITLE
chore: add ability to run publish workflow manually

### DIFF
--- a/.github/workflows/on-merge-pr.yml
+++ b/.github/workflows/on-merge-pr.yml
@@ -6,6 +6,8 @@ on:
       - closed
     branches:
       - main
+  workflow_dispatch: {}
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 


### PR DESCRIPTION
(debugging 403 response issue for pushing a version tag in an workflow)