### PR TITLE
Fix thread-safe command removal

### DIFF
--- a/src/Library/MongoInstrumentation.cs
+++ b/src/Library/MongoInstrumentation.cs
@@ -27,7 +27,7 @@ public static class MongoInstrumentation
     {
         public int RawSizeInBytes { get; set; }
 
-        public Dictionary<string, object> Command { get; set; }
+        public required Dictionary<string, object> Command { get; set; }
     }
 
     private static readonly ConcurrentDictionary<int, CommandInfo> Commands = new();
@@ -105,7 +105,7 @@ public static class MongoInstrumentation
             return;
         }
 
-        if (Commands.Remove(e.RequestId, out var commandInfo))
+        if (Commands.TryRemove(e.RequestId, out var commandInfo))
         {
             var targetCollection = GetCollection(e.CommandName, commandInfo.Command);
             if (targetCollection == string.Empty)
@@ -137,7 +137,7 @@ public static class MongoInstrumentation
             return;
         }
 
-        if (Commands.Remove(e.RequestId, out var commandInfo))
+        if (Commands.TryRemove(e.RequestId, out var commandInfo))
         {
             var targetCollection = GetCollection(e.CommandName, commandInfo.Command);
             if (targetCollection == string.Empty)


### PR DESCRIPTION
## Summary
- use `TryRemove` instead of `Remove` when cleaning up commands

## Testing
- `dotnet restore` *(fails: Unable to load the service index)*
- `dotnet format --no-restore` *(fails: Required references did not load)*

------
https://chatgpt.com/codex/tasks/task_e_686d8f635470832397b79bc0d7352ad1