### PR TITLE
Limit metrics provider registration to library assembly

### DIFF
--- a/tests/prometheus-net.Contrib.MongoDb.Tests/MetricProviderRegistrarTests.cs
+++ b/tests/prometheus-net.Contrib.MongoDb.Tests/MetricProviderRegistrarTests.cs
@@ -1,0 +1,21 @@
+using PrometheusNet.MongoDb;
+using PrometheusNet.MongoDb.Handlers;
+using Xunit;
+
+namespace PrometheusNet.Contrib.MongoDb.Tests;
+
+public class MetricProviderRegistrarTests
+{
+    [Fact]
+    public void DoesNotRegisterProvidersFromOtherAssemblies()
+    {
+        var isRegistered = MetricProviderRegistrar.TryGetProvider<TestMetricProvider>(out var provider);
+
+        Assert.False(isRegistered);
+        Assert.Null(provider);
+    }
+
+    private sealed class TestMetricProvider : IMongoDbClientMetricProvider
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- restrict metric provider discovery to specified assemblies while defaulting to the library assembly
- add an overload of `RegisterAll` that forwards the assemblies to the enumerator
- add a unit test that verifies providers from the test assembly are not auto-registered

## Testing
- dotnet format --verify-no-changes *(fails: existing whitespace/style violations in repository)*
- dotnet test


------
https://chatgpt.com/codex/tasks/task_e_68f290eda7d48323a938a4a4ef9fc0dc